### PR TITLE
Flush queue and "SafeBufferedAppender"

### DIFF
--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -184,7 +184,7 @@ namespace esp32m
      *       In this case, if the appender knows for sure that it will not be able to record messages at this time 
      *       (for example, no connection to the server, filesystem not mounted etc.), it must return @c false. 
      *       Otherwise, if the appender believes that it should be able to record the messages, it should return @c true
-     *       This behavior is exploited by buffering algorithms explained in the @c Logging::addBufferedAppender(...) or @c Logging::addSafeBufferedAppender(...)
+     *       This behavior is exploited by buffering algorithms explained in the @c Logging::addBufferedAppender(...)
      * @note This method SHOULD be thread-safe and take as little time as possible to record the message, unless message queue is installed, see @c Logging::useQueue(...)
      * @param message Message to be recorded, may be @c nullptr
      * @return @c true on success, @c false on failure
@@ -197,7 +197,6 @@ namespace esp32m
     friend class Logger;
     friend class Logging;
     friend class BufferedAppender;
-    friend class SafeBufferedAppender;
     friend class LogQueue;
   };
 
@@ -252,21 +251,11 @@ namespace esp32m
      * @param autoRelease If @c true, the buffer will be released automatically once the appender is ready to accept messages. 
      *                    May be set to @c false if it is known that the appender may temporarily loose the ability to record messages even after succesful initialization.
      *                    In this case, the buffer memory will never be released.
-     */
-    static void addBufferedAppender(LogAppender *a, int bufsiza = 1024, bool autoRelease = true);
-    
-    /**
-     * @brief Same idea as @c Logging::addBufferedAppender, adds appender that may need some time to initialize before it can record messages (for example, connect to the network, mount filesystem etc.) 
-     * The main difference with @c Logging::addBuferedAppender(), is that this "safe" appender will always try to re-sent the last item that has not yet been sent.
-     * This is not the behavior of the standard @c BufferAppender() : it will drop the item if it is not really sent (when append() return false)
-     * So "safe" appender keep in memory the item to be sent, and update to a new one only it has been realy sent, or if the buffer is full.
-     * This is the only case you can lost item : if buffer is full and we need to make some space to put new item in ring buffer.
-     * No need for an @c autoRelease option. Buffer is always keep.
-     * @param a Appender to be added
-     * @param bufsize Size of the circular buffer that keeps the most recent messages. If buffer overflows, it erases older messages until there's a space to record the most recent message.
      * @param maxLoopItems When @c Logging::useQueue() is used: amount of buffered items to be sent per Queue "flush" period. In order to avoid blocking the Queue task too much (and raised Watchdog interrupt), in case of long time appender (network, file...)
+     *                         This parameter is use only if safeItem is used too !
+     *
      */
-    static void addSafeBufferedAppender(LogAppender *a, int bufsiza = 1024, uint16_t maxLoopItems = 0);
+    static void addBufferedAppender(LogAppender *a, int bufsiza = 1024, bool autoRelease = true, uint32_t maxLoopItems = 0);
 
     /**
      * @brief Removes appender from the logging subsystem.

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -290,8 +290,12 @@ namespace esp32m
      * To work around these issues, a queue may be installed as an intemediate layer between the loggers and appenders. The messages are then collected in the queue, 
      * and processed sequentially in the dedicated thread, ensuring thread safety and no delay side-effects.
      * @param size Size of the queue. If set to 0, the queue will be removed.
+     * @param autoFlushPeriod Period in ms, to try to flush the BufferedAppender automatically.
+     *                        @c 0 = No flush period, normal behavior = Will try to flush on new entry.
+     *                        @c number_of_ms = Every period, the queue will loop on all appenders, and call @c append(nullptr), in order to force BufferedAppender to flush their buffer.
+     *                        @warning  Be careful, with standard @c Logging::BufferedAppender() it could result in loosing item, if appender is not ready, the item will be lost...
      */
-    static void useQueue(int size = 1024);
+    static void useQueue(int size = 1024, uint32_t autoFlushPeriod = 0);
 
     /**
      * @brief Hooks ESP32-specific logging mechanism, see @c esp_log_set_vprintf() in the esp-idf docs for details

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -230,7 +230,7 @@ namespace esp32m
   {
   public:
     /** 
-     * @brief This is the default logger to be used when @c Loggable instacne is not available
+     * @brief This is the default logger to be used when @c Loggable instance is not available
      */
     static Logger &system();
     

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -90,8 +90,8 @@ namespace esp32m
                     xSemaphoreGive(_lock);
                     // KO ! : No space left in buffer...
                     
-                    // Release _item_to_be_sent...
                     if(!_item_to_be_sent) {
+                        // Retreive item to be sent from the ring buffer : the older one.
                         xSemaphoreTake(_lock, portMAX_DELAY);
                         _item_to_be_sent = (LogMessage *)xRingbufferReceive(_handle, &size, 0);
                         xSemaphoreGive(_lock);
@@ -104,9 +104,9 @@ namespace esp32m
 
                     append_result = _appender.append(_item_to_be_sent); // Try to "send" item... last chance before loosing it due to buffer rotation!
                     xSemaphoreTake(_lock, portMAX_DELAY);
-                    vRingbufferReturnItem(_handle, _item_to_be_sent);
+                    vRingbufferReturnItem(_handle, _item_to_be_sent); // Here we remove item, even if it has not really been sent ! Free space in buffer...
                     xSemaphoreGive(_lock);
-                    _item_to_be_sent = nullptr; // Reset pointer, indicating the item has been removed from Ring buffere. Here we remove item, even if it has not really been sent ! Make place in buffer...
+                    _item_to_be_sent = nullptr; // Reset pointer, indicating the item has been removed from Ring buffer
                 }
             }
             else {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -80,7 +80,8 @@ namespace esp32m
                 xSemaphoreGive(_lock);
                 if (!item)
                     break;
-                ok &= _appender.append(item);
+                ok &= _appender.append(item); // BE CAREFUL : If for any reason, append() is not ok, the item is lost... (even if the while loop test is ok, it can change until here...)
+                xSemaphoreTake(_lock, portMAX_DELAY);
                 vRingbufferReturnItem(_handle, item);
                 xSemaphoreGive(_lock);
             }


### PR DESCRIPTION
Two points that my usage need :   
* Ability to flush `BufferedAppender` periodically (instead of only when new message to append)  
* Fix a potential lost of item in `BufferedAppender` : don't remove the item from the ring buffer if it failed to be "append" !  

So I add a `autoFlushPeriod` in `LogQueue` class, and then send `nullptr` messages to appenders to trigger the flush loop.  

And I create a "copy" of `BufferedAppender`, to change the behavior and avoid loosing messages.
This `SafeBufferedAppender` take care to not remove item if it has not really been sent.
Also include a `maxLoopItems`, to avoid infinite loop, that could take too much time of the Queue task and raised Watchdog interrupt! (When `useQueue`)

It's my first contribution to open source project, don't hesitated to comment and change necessary code if needed.