### PR TITLE
Add new param to set maximum file size for rotation + New rotation filename naming to keep file extension.

### DIFF
--- a/include/fs-appender.hpp
+++ b/include/fs-appender.hpp
@@ -13,18 +13,19 @@ namespace esp32m
     class FSAppender : public FormattingAppender
     {
     public:
-        FSAppender(FS &fs, const char *name, uint8_t maxFiles = 1) : _fs(fs), _name(name), _maxFiles(maxFiles), _lock(xSemaphoreCreateRecursiveMutex()) {}
+        FSAppender(FS &fs, const char *name, uint8_t maxFiles = 1, uint32_t maxFileSizeBytes=8192) : _fs(fs), _name(name), _maxFiles(maxFiles), _maxFileSizeBytes(maxFileSizeBytes), _lock(xSemaphoreCreateRecursiveMutex()) {}
         FSAppender(const FSAppender &) = delete;
 
     protected:
         virtual bool append(const char *message);
-        virtual bool shouldRotate(File &f) { return f.size() > 8192; }
+        virtual bool shouldRotate(File &f) { return f.size() > _maxFileSizeBytes; }
 
     private:
         FS &_fs;
         File _file;
         const char *_name;
         uint8_t _maxFiles;
+        uint32_t _maxFileSizeBytes;
         SemaphoreHandle_t _lock;
     };
 

--- a/include/fs-appender.hpp
+++ b/include/fs-appender.hpp
@@ -27,6 +27,8 @@ namespace esp32m
         uint8_t _maxFiles;
         uint32_t _maxFileSizeBytes;
         SemaphoreHandle_t _lock;
+
+        String newFilename(uint8_t idx); // Max 512 files on disk
     };
 
 } // namespace esp32m

--- a/src/fs_appender.cpp
+++ b/src/fs_appender.cpp
@@ -21,14 +21,12 @@ namespace esp32m
                 a = _name;
                 if (i)
                 {
-                    a.concat('.');
-                    a.concat(i);
+                    a = newFilename(i);
                 }
                 if (_fs.exists(a))
                 {
-                    b = _name;
-                    b.concat('.');
-                    b.concat(i + 1);
+                    b = newFilename(i+1);
+
                     if (_fs.exists(b))
                         _fs.remove(b);
                     _fs.rename(a, b);
@@ -44,6 +42,28 @@ namespace esp32m
         }
         xSemaphoreGiveRecursive(_lock);
         return result;
+    }
+
+    String FSAppender::newFilename(uint8_t i) {
+        auto rn = strlen(_name) + 1 + 3 + 1; // Reserve space for 3 digits file index : Max 512 (uint8_t) files on disk
+        String newName;
+        newName.reserve(rn);
+        newName = _name;
+
+        int extIdx = newName.lastIndexOf('.');
+        if(extIdx >= 0) {
+            String ext = newName.substring(extIdx);
+            newName = newName.substring(0, extIdx); // Name without file extension
+            newName.concat('.');
+            newName.concat(i);
+            newName.concat(ext);
+        }
+        else {
+            newName.concat('.');
+            newName.concat(i);
+        }
+
+        return newName;
     }
 
 } // namespace esp32m


### PR DESCRIPTION
This is useful to adjust file size rotation.  
8192 bytes is quite low for some logs.