### PR TITLE
Add an method to explicitly close a FSAppender

### DIFF
--- a/include/fs-appender.hpp
+++ b/include/fs-appender.hpp
@@ -15,6 +15,7 @@ namespace esp32m
     public:
         FSAppender(FS &fs, const char *name, uint8_t maxFiles = 1, uint32_t maxFileSizeBytes=8192) : _fs(fs), _name(name), _maxFiles(maxFiles), _maxFileSizeBytes(maxFileSizeBytes), _lock(xSemaphoreCreateRecursiveMutex()) {}
         FSAppender(const FSAppender &) = delete;
+        virtual bool close();
 
     protected:
         virtual bool append(const char *message);

--- a/src/fs_appender.cpp
+++ b/src/fs_appender.cpp
@@ -66,4 +66,17 @@ namespace esp32m
         return newName;
     }
 
+    // Flushes and closes the file.
+    // Returns true if a file was closed.
+    // Returns false otherwise.
+    bool FSAppender::close(){
+        if (_file){
+            xSemaphoreTakeRecursive(_lock, portMAX_DELAY);
+            _file.close();
+            xSemaphoreGiveRecursive(_lock);
+            return true;
+        }
+        return false;
+    }
+
 } // namespace esp32m


### PR DESCRIPTION
This will cause a flush of the file and is useful for applications wishing to copy / upload the logfile at runtime.

Continued logging will work, but will re-open file, so you may wish to remove the appender before calling close().