### PR TITLE
Platform agnostic uart write char support

### DIFF
--- a/include/platform-uart.hpp
+++ b/include/platform-uart.hpp
@@ -1,0 +1,6 @@
+#ifndef ESP32M_LOGGING_ETS_APPENDER_UART_FUNC
+#include "rom/uart.h"
+    const auto platform_write_char_uart = ets_write_char_uart;
+#else
+    const auto platform_write_char_uart = ESP32M_LOGGING_ETS_APPENDER_UART_FUNC;
+#endif

--- a/src/ets-appender.cpp
+++ b/src/ets-appender.cpp
@@ -1,5 +1,5 @@
 #include <string.h>
-
+#include "platform-uart.hpp"
 #include "ets-appender.hpp"
 
 namespace esp32m {
@@ -16,8 +16,8 @@ namespace esp32m {
         {
             auto l = strlen(message);
             for (auto i = 0; i < l; i++)
-                ets_write_char_uart(message[i]);
-            ets_write_char_uart('\n');
+                platform_write_char_uart(message[i]);
+            platform_write_char_uart('\n');
         }
 
         return true;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -11,6 +11,7 @@
 #include <esp32-hal.h>
 
 #include "logging.hpp"
+#include "platform-uart.hpp"
 
 namespace esp32m
 {
@@ -596,7 +597,7 @@ namespace esp32m
         }
         ~SerialHook()
         {
-            ets_install_putc1(ets_write_char_uart);
+            ets_install_putc1(platform_write_char_uart);
             xSemaphoreTake(_lock, portMAX_DELAY);
             free(_serialBuf);
             _serialBufLen = 0;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,6 +1,7 @@
 #include <malloc.h>
 #include <string.h>
 #include <time.h>
+#include <ctype.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/ringbuf.h>
 #include <freertos/semphr.h>


### PR DESCRIPTION
@dyarkovoy This PR addresses https://github.com/esp32m/logging/issues/18.

Solution implemented: 
- user definable "uart write function" with fallback to the `ets_write_char_uart` for backward compatibility.